### PR TITLE
Improve the URI service to support authority as well.

### DIFF
--- a/src/uri.rs
+++ b/src/uri.rs
@@ -11,18 +11,20 @@
 use chateau::client::pool::PoolableConnection;
 use hyperdriver::client::conn::Connection;
 
-/// A layer that sets the scheme of the URI to a default.
+/// A layer that sets the scheme of the URI to a default,
+/// and optionally sets the authority of the URI.
 ///
 /// Defaults to `http` via the `Default` implementation.
 #[derive(Debug, Clone)]
 pub struct ProxyUriLayer {
     scheme: http::uri::Scheme,
+    authority: Option<http::uri::Authority>,
 }
 
 impl ProxyUriLayer {
     /// Create a new `ProxyUriLayer` with the given scheme
-    pub fn new(scheme: http::uri::Scheme) -> Self {
-        Self { scheme }
+    pub fn new(scheme: http::uri::Scheme, authority: Option<http::uri::Authority>) -> Self {
+        Self { scheme, authority }
     }
 }
 
@@ -30,13 +32,14 @@ impl Default for ProxyUriLayer {
     fn default() -> Self {
         Self {
             scheme: http::uri::Scheme::HTTP,
+            authority: None,
         }
     }
 }
 
 impl From<http::uri::Scheme> for ProxyUriLayer {
     fn from(scheme: http::uri::Scheme) -> Self {
-        Self::new(scheme)
+        Self::new(scheme, None)
     }
 }
 
@@ -46,6 +49,7 @@ impl<S> tower::layer::Layer<S> for ProxyUriLayer {
     fn layer(&self, service: S) -> Self::Service {
         ProxyUriService {
             scheme: self.scheme.clone(),
+            authority: self.authority.clone(),
             service,
         }
     }
@@ -55,18 +59,30 @@ impl<S> tower::layer::Layer<S> for ProxyUriLayer {
 #[derive(Debug, Clone)]
 pub struct ProxyUriService<S> {
     scheme: http::uri::Scheme,
+    authority: Option<http::uri::Authority>,
     service: S,
 }
 
 impl<S> ProxyUriService<S> {
     /// Create a new `ProxyUriService` with the given scheme
-    pub fn new(scheme: http::uri::Scheme, service: S) -> Self {
-        Self { scheme, service }
+    pub fn new(
+        scheme: http::uri::Scheme,
+        authority: Option<http::uri::Authority>,
+        service: S,
+    ) -> Self {
+        Self {
+            scheme,
+            authority,
+            service,
+        }
     }
 
     /// Create a new `ProxyUriLayer` with the given scheme
-    pub fn layer(scheme: http::uri::Scheme) -> ProxyUriLayer {
-        ProxyUriLayer::new(scheme)
+    pub fn layer(
+        scheme: http::uri::Scheme,
+        authority: Option<http::uri::Authority>,
+    ) -> ProxyUriLayer {
+        ProxyUriLayer::new(scheme, authority)
     }
 
     /// The default scheme used by this service.
@@ -74,16 +90,26 @@ impl<S> ProxyUriService<S> {
         &self.scheme
     }
 
+    /// The default authority used by this service.
+    pub fn authority(&self) -> Option<&http::uri::Authority> {
+        self.authority.as_ref()
+    }
+
     /// Unwrap the inner service
     pub fn into_inner(self) -> S {
         self.service
     }
 
-    fn set_scheme<B>(&self, req: &mut http::Request<B>) {
+    fn apply<B>(&self, req: &mut http::Request<B>) {
         let mut uri = req.uri().clone().into_parts();
-        if uri.scheme.is_none() {
-            uri.scheme = Some(self.scheme.clone());
-        }
+        let authority = req
+            .extensions()
+            .get()
+            .or(self.authority.as_ref())
+            .or(uri.authority.as_ref());
+
+        uri.authority = authority.cloned();
+        uri.scheme = Some(self.scheme.clone());
 
         *req.uri_mut() = http::Uri::from_parts(uri).expect("valid uri with scheme");
     }
@@ -98,7 +124,7 @@ where
     type Future = S::Future;
 
     fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
-        self.set_scheme(&mut req);
+        self.apply(&mut req);
 
         self.service.call(req)
     }
@@ -122,7 +148,7 @@ where
     type Future = S::Future;
 
     fn call(&mut self, mut req: (C, http::Request<B>)) -> Self::Future {
-        self.set_scheme(&mut req.1);
+        self.apply(&mut req.1);
 
         self.service.call(req)
     }
@@ -132,5 +158,68 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
         self.service.poll_ready(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_apply_with_scheme() {
+        let mut req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com")
+            .body(())
+            .unwrap();
+        let uri_service = ProxyUriService::new(http::uri::Scheme::HTTP, None, ());
+        uri_service.apply(&mut req);
+        assert_eq!(req.uri().scheme(), Some(&http::uri::Scheme::HTTP));
+        assert_eq!(
+            req.uri().authority(),
+            Some(&http::uri::Authority::from_static("example.com"))
+        );
+    }
+
+    #[test]
+    fn test_apply_with_scheme_and_authority() {
+        let mut req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com")
+            .body(())
+            .unwrap();
+        let uri_service = ProxyUriService::new(
+            http::uri::Scheme::HTTP,
+            Some(http::uri::Authority::from_static("proxy.example.com")),
+            (),
+        );
+        uri_service.apply(&mut req);
+        assert_eq!(req.uri().scheme(), Some(&http::uri::Scheme::HTTP));
+        assert_eq!(
+            req.uri().authority(),
+            Some(&http::uri::Authority::from_static("proxy.example.com"))
+        );
+    }
+
+    #[test]
+    fn test_apply_with_extension_authority() {
+        let mut req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://example.com")
+            .body(())
+            .unwrap();
+        req.extensions_mut()
+            .insert(http::uri::Authority::from_static("elsewhere.example.com"));
+        let uri_service = ProxyUriService::new(
+            http::uri::Scheme::HTTP,
+            Some(http::uri::Authority::from_static("proxy.example.com")),
+            (),
+        );
+        uri_service.apply(&mut req);
+        assert_eq!(req.uri().scheme(), Some(&http::uri::Scheme::HTTP));
+        assert_eq!(
+            req.uri().authority(),
+            Some(&http::uri::Authority::from_static("elsewhere.example.com"))
+        );
     }
 }


### PR DESCRIPTION
Often a proxy will target a different authority and need to replace the one in the URI. The service supports a static Authority, and reading the authority from the request extensions.